### PR TITLE
Add support for environment variables in command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,15 @@ export type WorkflowConfig = {
   continueOnFail?: boolean
 }
 
+export type EnvironmentVariables = {
+  [key: string]: string;
+}
+
 type WorkflowOptions = {
   path?: string
   secrets?: WorkflowOptionsSecrets
   ee?: EventEmitter
+  env?: EnvironmentVariables
 }
 
 type WorkflowOptionsSecrets = {
@@ -323,7 +328,8 @@ export async function runFromFile (path: string, options?: WorkflowOptions): Pro
 // Run workflow
 export async function run (workflow: Workflow, options?: WorkflowOptions): Promise<WorkflowResult> {
   const timestamp = new Date()
-  const tests = await Promise.all(Object.values(workflow.tests).map((test, i) => runTest(Object.keys(workflow.tests)[i], test, options, workflow.config, workflow.env, workflow.components)))
+  const env = { ...workflow.env ?? {}, ...options?.env ?? {} }
+  const tests = await Promise.all(Object.values(workflow.tests).map((test, i) => runTest(Object.keys(workflow.tests)[i], test, options, workflow.config, env, workflow.components)))
 
   const workflowResult: WorkflowResult = {
     workflow,


### PR DESCRIPTION
According to feature request https://github.com/stepci/stepci/issues/9 this PR adds support for environment variables set as argument. The arguments will override the settings in the workflow file.