### PR TITLE
Adding support for retries in HTTP requests, setting default retries to 0 (instead of current, 2)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ export type HTTPStep = {
   check?: HTTPStepCheck
   followRedirects?: boolean
   timeout?: number
+  retries?: number
 }
 
 export type HTTPStepTRPC = {
@@ -572,6 +573,7 @@ async function runTest (id: string, test: Test, schemaValidator: Ajv, options?: 
             throwHttpErrors: false,
             followRedirect: step.http.followRedirects ?? true,
             timeout: step.http.timeout,
+            retry: step.http.retries ?? 0,
             cookieJar: cookies,
             https: {
               ...clientCredentials,


### PR DESCRIPTION
Using the got() library the default retries is set to 2.  This can lead to unexpected results in regards to timeouts, specifically that when I set a timeout for a request, the request will take 3 times longer to finish (if failing/timing out) because the request is auto-retried 2 additional times.  This default hardcoded into got() and used by this library makes it somewhat confusing and inaccurate as far as expected return times for requests.  If I set a timeout of, say, 10 seconds, I'd expect stepci runner to exit with failure after 10 seconds, but because of the auto-retries being set at twice during a failure it actually takes 30 seconds.  This auto-retry logic baked into got() also can lead to unexpectedly "spamming" requests to providers which the end-user wouldn't even know about unless they subscribed to the event stream or viewed the logs of their server they are monitoring.  Based on my experience with other testing libraries and frameworks, they generally do not have retry logic baked into a testing framework such as this.

Based on that information and experience, what I've done in this commit is the following...
* Adding the ability to set the retries to any value in an `http:` object
* Set the retries to 0 by default so we don't unexpectedly overload or make extra requests without the user desiring it