### PR TITLE
Replace circular object references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stepci/runner",
-  "version": "1.11.6",
+  "version": "1.11.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stepci/runner",
-      "version": "1.11.6",
+      "version": "1.11.8",
       "license": "MPL-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",
@@ -32,6 +32,7 @@
         "parse-duration": "^1.1.0",
         "phasic": "^1.0.2",
         "proxy-agent": "^6.3.1",
+        "replace-circular-object": "^1.0.1",
         "simple-statistics": "^7.8.0",
         "tough-cookie": "^4.1.2",
         "xpath": "^0.0.32"
@@ -1992,6 +1993,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/replace-circular-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-circular-object/-/replace-circular-object-1.0.1.tgz",
+      "integrity": "sha512-JZhjqtv/+tahpbnsYxngEJekAegbIjI4kYC0qgNfehlOuHEBAeaIKdDmhzU/H34pO2Ms97O4Cd1L9WyPlCvSyw==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3869,6 +3878,11 @@
         "define-properties": "^1.1.3",
         "functions-have-names": "^1.2.2"
       }
+    },
+    "replace-circular-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-circular-object/-/replace-circular-object-1.0.1.tgz",
+      "integrity": "sha512-JZhjqtv/+tahpbnsYxngEJekAegbIjI4kYC0qgNfehlOuHEBAeaIKdDmhzU/H34pO2Ms97O4Cd1L9WyPlCvSyw=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "parse-duration": "^1.1.0",
     "phasic": "^1.0.2",
     "proxy-agent": "^6.3.1",
+    "replace-circular-object": "^1.0.1",
     "simple-statistics": "^7.8.0",
     "tough-cookie": "^4.1.2",
     "xpath": "^0.0.32"

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { parseCSV, TestData } from './utils/testdata'
 import { CapturesStorage, checkCondition, getCookie, didChecksPass } from './utils/runner'
 import { Credential, CredentialsStorage, HTTPCertificate, TLSCertificate, getAuthHeader, getClientCertificate, getTLSCertificate } from './utils/auth'
 import { tryFile, StepFile } from './utils/files'
+import replaceCircularObject from 'replace-circular-object';
 
 export type Workflow = {
   version: string
@@ -453,7 +454,9 @@ export async function run(workflow: Workflow, options?: WorkflowOptions): Promis
     env = renderObject(env, { env, secrets: options?.secrets }, { delimiters: templateDelimiters })
   }
 
+  workflow.tests = replaceCircularObject(workflow.tests) as Tests;
   if (workflow.components) {
+    workflow.components = replaceCircularObject(workflow.components) as WorkflowComponents;
     workflow.components = renderObject(workflow.components, { env, secrets: options?.secrets }, { delimiters: templateDelimiters })
   }
 


### PR DESCRIPTION
Schemas with circular references may result in an infinite loop, triggering a "Maximum call stack size exceeded" error.

In this solution, I have incorporated a custom-made library called [replace-circular-object](https://github.com/sngular/replace-circular-object) to replace `workflow.tests` and `workflow.components` with a copy devoid of circular references, if any exist.

To reproduce the error you could use this **example of circular reference workflow**:
```
version: "1.0"
name: Circular Person API
config:
  http:
    baseURL: http://localhost:1234
tests:
  default:
    name: Default
    steps:
      - name: Returns a Person
        http:
          url: /
          method: GET
          check:
            status: 200
            schema:
              $ref: "#/components/schemas/Person"
components:
  schemas:
    Person:
      type: object
      properties:
        name:
          type: string
        sibling:
          $ref: "#/components/schemas/Person"
      additionalProperties: false
```

Generated by using this OpenAPI document
```
openapi: 3.0.1
info:
  title: Circular Person API
  version: 1.0.0
  description: Test circular reference
servers:
  - url: http://localhost:1234
paths:
  /:
    get:
      summary: Returns a Person
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Person'

components:
  schemas:
    Person:
      type: object
      properties:
        name:
          type: string
        sibling:
          $ref: '#/components/schemas/Person'
      additionalProperties: false
```