### PR TITLE
Added filenname to formData

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -808,6 +808,7 @@ async function runTest(id: string, test: Test, schemaValidator: Ajv, options?: W
               }
             }
           }
+
           if (step.http.check) {
             stepResult.checks = {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -660,8 +660,10 @@ async function runTest(id: string, test: Test, schemaValidator: Ajv, options?: W
               }
 
               if ((step.http.formData[field] as StepFile).file) {
-                const file = await fs.promises.readFile(path.join(path.dirname(options?.path || __dirname), (step.http.formData[field] as StepFile).file))
-                formData.append(field, file)
+                const filepath = path.join(path.dirname(options?.path || __dirname), (step.http.formData[field] as StepFile).file)
+                const file = await fs.promises.readFile(filepath)
+                const filename = path.parse(filepath).base
+                formData.append(field, file, filename)
               }
             }
 
@@ -806,7 +808,6 @@ async function runTest(id: string, test: Test, schemaValidator: Ajv, options?: W
               }
             }
           }
-
           if (step.http.check) {
             stepResult.checks = {}
 


### PR DESCRIPTION
This addresses issue [#195](https://github.com/stepci/stepci/issues/195) in the main StepCI repo.

The filename is appended to the form data which should be added according to RFC7578. At least all major Python API Frameworks need this to parse the file correctly. 

