### PR TITLE
Feature/multipart form data content type

### DIFF
--- a/src/steps/http.ts
+++ b/src/steps/http.ts
@@ -283,27 +283,22 @@ export default async function (
   if (params.formData) {
     const formData = new FormData()
     for (const field in params.formData) {
-      let appendOptions = {} as FormData.AppendOptions;
-      var value : any
+      const appendOptions = {} as FormData.AppendOptions
       if (typeof params.formData[field] === 'string') {
-        value = params.formData[field] as string
+        formData.append(field, params.formData[field])
       } else if ((params.formData[field] as HTTPRequestPart).value) {
         const requestPart = params.formData[field] as HTTPRequestPart
-        value = requestPart.value
-        if (requestPart.type) {
-          appendOptions.contentType = requestPart.type
-        }
+        appendOptions.contentType = requestPart.type
+        formData.append(field, requestPart.value, appendOptions)
       } else if ((params.formData[field] as StepFile).file) {
         const stepFile = params.formData[field] as StepFile
         const filepath = path.join(
           path.dirname(options?.path || __dirname),
           stepFile.file
         )
-
-        value = await fs.promises.readFile(filepath)
         appendOptions.filename = path.parse(filepath).base
+        formData.append(field, await fs.promises.readFile(filepath), appendOptions)
       }
-      formData.append(field, value, appendOptions)
     }
 
     requestBody = formData

--- a/tests/multipart.yml
+++ b/tests/multipart.yml
@@ -1,0 +1,24 @@
+version: "1.1"
+name: Multipart
+tests:
+  multipart:
+    steps:
+      - name: Multipart
+        http:
+          url: https://httpbin.org/post
+          method: POST
+          formData:
+            foo: bar
+            jsonfield:
+              value: '{ "foo": "bar" }'
+              type: application/json
+            filefield:
+              file: example.json
+              type: application/json
+          check:
+            status: 200
+            jsonpath:
+              $.files.filefield:
+                - isNull: false
+              $.form.foo: bar
+                

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -3,3 +3,4 @@ import { EventEmitter } from 'node:events'
 
 const ee = new EventEmitter()
 runFromFile('./tests/basic.yml').then(({ result }) => console.log(result.tests[0].steps))
+runFromFile('./tests/multipart.yml').then(({ result }) => console.log(result.tests[0].steps))


### PR DESCRIPTION
Added support for 'Content-Type' for multipart requests:

```
          formData:
            foo: bar
            patient:
              value: '{"reference":"a97a62d5-9f33-470d-aa05-d39ed3570105", "name": "john doe" }'
              type: application/json
            payer:
              file: bla.pdf
              type: application/pdf
```

Results in:
```
POST /post HTTP/1.1
Content-Type: multipart/form-data; boundary=WebAppBoundary

--WebAppBoundary
Content-Disposition: form-data; name="patient"; filename="bla.json"
Content-Type: application/json

{"reference":"a97a62d5-9f33-470d-aa05-d39ed3570105", "name": "john doe" }
--WebAppBoundary
Content-Disposition: form-data; name="payer"; filename="bla.pdf"
Content-Type: application/pdf
```