### PR TITLE
Add `before` and `after` sections

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,9 @@ export type Workflow = {
    * @deprecated Import files using `$refs` instead.
   */
   include?: string[]
+  before?: Test
   tests: Tests
+  after?: Test
   components?: WorkflowComponents
   config?: WorkflowConfig
 }
@@ -237,10 +239,17 @@ export async function run(workflow: Workflow, options?: WorkflowOptions): Promis
   const concurrency = options?.concurrency || workflow.config?.concurrency || Object.keys(workflow.tests).length
   const limit = pLimit(concurrency <= 0 ? 1 : concurrency)
 
+  let testResults: TestResult[] = []
+
+  if (workflow.before) {
+    const beforeResult = await runTest('before', workflow.before, schemaValidator, options, workflow.config, env)
+    testResults.push(beforeResult)
+  }
+
   const input: Promise<TestResult>[] = []
   Object.entries(workflow.tests).map(([id, test]) => input.push(limit(() => runTest(id, test, schemaValidator, options, workflow.config, env))))
 
-  const testResults = await Promise.all(input)
+  testResults.push(...await Promise.all(input))
   const workflowResult: WorkflowResult = {
     workflow,
     result: {
@@ -253,6 +262,11 @@ export async function run(workflow: Workflow, options?: WorkflowOptions): Promis
       bytesReceived: testResults.map(test => test.bytesReceived).reduce((a, b) => a + b),
     },
     path: options?.path
+  }
+
+  if (workflow.after) {
+    const afterResult = await runTest('after', workflow.after, schemaValidator, options, workflow.config, env)
+    testResults.push(afterResult)
   }
 
   options?.ee?.emit('workflow:result', workflowResult)


### PR DESCRIPTION
This PR adds `before` and `after` sections [like Artillery has](https://www.artillery.io/docs/reference/test-script#before-and-after-sections). There is only one item per section, and it works the exact same as a regular test (in the `tests` section). We could want to avoid reporting steps in `before` and `after` as tests, but that would require more substantial changes and I figured it would be better to keep it simple and easy to understand.

Note: If #117 is merged and [my suggestion](https://github.com/stepci/runner/pull/117#issuecomment-2122943205) not accepted, we will need to add liquidless rendering for `before` and `after` sections too.