### PR TITLE
Propagate captures from `before` section

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -252,7 +252,7 @@ export async function run(workflow: Workflow, options?: WorkflowOptions): Promis
   const concurrency = options?.concurrency || workflow.config?.concurrency || Object.keys(workflow.tests).length
   const limit = pLimit(concurrency <= 0 ? 1 : concurrency)
 
-  let testResults: TestResult[] = []
+  const testResults: TestResult[] = []
   const captures: CapturesStorage = {}
 
   // Run `before` section


### PR DESCRIPTION
While documenting the `before` and `after` sections (#118) I realized I didn't make it so captures from `before` are available in `tests` and `after`. This PR fixes it.