### PR TITLE
added support for specifying json convenience object

### DIFF
--- a/src/steps/http.ts
+++ b/src/steps/http.ts
@@ -92,11 +92,6 @@ export type HTTPRequestPart = {
   json?: object
 }
 
-export type HTTPRequestPartJson = {
-  json: object
-}
-
-
 export type HTTPStepMultiPartForm = {
   [key: string]: string | StepFile | HTTPRequestPart
 }
@@ -301,7 +296,7 @@ export default async function (
         formData.append(field, await fs.promises.readFile(filepath), appendOptions)
       } else {
         const requestPart = params.formData[field] as HTTPRequestPart
-        if (requestPart.json) {
+        if (requestPart.json != null) {
           appendOptions.contentType = 'application/json'
           formData.append(field, JSON.stringify(requestPart.json), appendOptions)
         } else {

--- a/src/steps/http.ts
+++ b/src/steps/http.ts
@@ -296,7 +296,7 @@ export default async function (
         formData.append(field, await fs.promises.readFile(filepath), appendOptions)
       } else {
         const requestPart = params.formData[field] as HTTPRequestPart
-        if (requestPart.json != null) {
+        if ('json' in requestPart) {
           appendOptions.contentType = 'application/json'
           formData.append(field, JSON.stringify(requestPart.json), appendOptions)
         } else {

--- a/src/steps/http.ts
+++ b/src/steps/http.ts
@@ -289,7 +289,7 @@ export default async function (
     const formData = new FormData()
     for (const field in params.formData) {
       const appendOptions = {} as FormData.AppendOptions
-      if (typeof params.formData[field] === 'string') {
+      if (typeof params.formData[field] != 'object') {
         formData.append(field, params.formData[field])
       } else if ((params.formData[field] as StepFile).file) {
         const stepFile = params.formData[field] as StepFile

--- a/src/steps/http.ts
+++ b/src/steps/http.ts
@@ -88,7 +88,12 @@ export type HTTPStepForm = {
 
 export type HTTPRequestPart = {
   type?: string
-  value: string
+  value?: string
+  json?: object
+}
+
+export type HTTPRequestPartJson = {
+  json: object
 }
 
 
@@ -286,10 +291,6 @@ export default async function (
       const appendOptions = {} as FormData.AppendOptions
       if (typeof params.formData[field] === 'string') {
         formData.append(field, params.formData[field])
-      } else if ((params.formData[field] as HTTPRequestPart).value) {
-        const requestPart = params.formData[field] as HTTPRequestPart
-        appendOptions.contentType = requestPart.type
-        formData.append(field, requestPart.value, appendOptions)
       } else if ((params.formData[field] as StepFile).file) {
         const stepFile = params.formData[field] as StepFile
         const filepath = path.join(
@@ -298,6 +299,15 @@ export default async function (
         )
         appendOptions.filename = path.parse(filepath).base
         formData.append(field, await fs.promises.readFile(filepath), appendOptions)
+      } else {
+        const requestPart = params.formData[field] as HTTPRequestPart
+        if (requestPart.json) {
+          appendOptions.contentType = 'application/json'
+          formData.append(field, JSON.stringify(requestPart.json), appendOptions)
+        } else {
+          appendOptions.contentType = requestPart.type
+          formData.append(field, requestPart.value, appendOptions)
+        }
       }
     }
 

--- a/tests/multipart.yml
+++ b/tests/multipart.yml
@@ -9,9 +9,12 @@ tests:
           method: POST
           formData:
             foo: bar
+            bar:
+              value: jane
             jsonfield:
-              value: '{ "foo": "bar" }'
-              type: application/json
+              json:
+                foo: bar
+                bar: foo
             filefield:
               file: example.json
               type: application/json
@@ -21,4 +24,6 @@ tests:
               $.files.filefield:
                 - isNull: false
               $.form.foo: bar
+              $.form.bar: jane
+              $.form.jsonfield: '{"foo":"bar","bar":"foo"}'
                 

--- a/tests/multipart.yml
+++ b/tests/multipart.yml
@@ -15,6 +15,10 @@ tests:
               json:
                 foo: bar
                 bar: foo
+            jsonfieldarray:
+              json:
+                - foo1: bar1
+                - foo2: bar2
             filefield:
               file: example.json
               type: application/json
@@ -26,4 +30,4 @@ tests:
               $.form.foo: bar
               $.form.bar: jane
               $.form.jsonfield: '{"foo":"bar","bar":"foo"}'
-                
+              $.form.jsonfieldarray: '[{"foo1":"bar1"},{"foo2":"bar2"}]'


### PR DESCRIPTION
Allows you to conveniently use `json` field for multipart forms:

```
        http:
          url: https://httpbin.org/post
          method: POST
          formData:
            myfield:
              json:
                foo: bar
                bar: foo
```
The YAML will be converted to JSON, and the content-type set to 'application/json'.