### PR TITLE
Add oauth options to support Microsoft EntraID as IdP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stepci/runner",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stepci/runner",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stepci/runner",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Step CI Runner",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Added OAuth options `contentType` and `scope` to enable OAuth2 token requests for Microsoft EntraID resources.